### PR TITLE
don't try to close the temp file twice, otherwise Close() returns an error

### DIFF
--- a/file.go
+++ b/file.go
@@ -88,10 +88,17 @@ func (w *File) Accept() error {
 	}
 	w.file = nil
 
+	// flush any data to disk
 	w.tempFile.Close()
-	err := os.Rename(w.tempFilename, w.filename)
-	w.Close()
-	return err
+
+	// rename the temp file to the real file
+	if err := os.Rename(w.tempFilename, w.filename); err != nil {
+		return w.Close()
+	} else {
+		// if successful, set the closed *os.File to nil
+		w.tempFile = nil
+		return nil
+	}
 }
 
 // Close cleans up the internal file objects.

--- a/file.go
+++ b/file.go
@@ -90,15 +90,11 @@ func (w *File) Accept() error {
 
 	// flush any data to disk
 	w.tempFile.Close()
+	w.tempFile = nil
 
 	// rename the temp file to the real file
-	if err := os.Rename(w.tempFilename, w.filename); err != nil {
-		return w.Close()
-	} else {
-		// if successful, set the closed *os.File to nil
-		w.tempFile = nil
-		return nil
-	}
+	// no need to call Close() because w.tempFile and w.file are now nil
+	return os.Rename(w.tempFilename, w.filename)
 }
 
 // Close cleans up the internal file objects.


### PR DESCRIPTION
```
--- FAIL: TestFile (0.00 seconds)
    file_test.go:171: /Users/rick/p/go-contentaddressable/file_test.go:37
        Expected: <nil>
        Actual:   invalid argument
```

The invalid argument came from trying to close the `w.tempFile` twice.  This sets it to nil so an extra `w.Close()` doesn't return an error.
