### PR TITLE
sync tempfile before closing and renaming

### DIFF
--- a/file.go
+++ b/file.go
@@ -108,6 +108,7 @@ func (w *File) Accept() error {
 		return err
 	}
 	if err := w.tempFile.Close(); err != nil {
+		w.Close()
 		return err
 	}
 	w.tempFile = nil

--- a/file.go
+++ b/file.go
@@ -105,6 +105,7 @@ func (w *File) Accept() error {
 
 	// flush any data to disk
 	if err := w.tempFile.Sync(); err != nil {
+		w.Close()
 		return err
 	}
 	if err := w.tempFile.Close(); err != nil {

--- a/file.go
+++ b/file.go
@@ -98,18 +98,15 @@ func (w *File) Accept() error {
 	}
 
 	if err := cleanupFile(w.file, w.filename); err != nil {
-		w.Close()
 		return err
 	}
 	w.file = nil
 
 	// flush any data to disk
 	if err := w.tempFile.Sync(); err != nil {
-		w.Close()
 		return err
 	}
 	if err := w.tempFile.Close(); err != nil {
-		w.Close()
 		return err
 	}
 	w.tempFile = nil

--- a/file.go
+++ b/file.go
@@ -96,7 +96,12 @@ func (w *File) Accept() error {
 	w.file = nil
 
 	// flush any data to disk
-	w.tempFile.Close()
+	if err := w.tempFile.Sync(); err != nil {
+		return err
+	}
+	if err := w.tempFile.Close(); err != nil {
+		return err
+	}
 	w.tempFile = nil
 
 	// rename the temp file to the real file

--- a/file_test.go
+++ b/file_test.go
@@ -12,7 +12,7 @@ import (
 
 var supOid = "a2b71d6ee8997eb87b25ab42d566c44f6a32871752c7c73eb5578cb1182f7be0"
 
-func TestFile(t *testing.T) {
+func TestFileAccept(t *testing.T) {
 	test := SetupFile(t)
 	defer test.Teardown()
 

--- a/file_test.go
+++ b/file_test.go
@@ -114,6 +114,13 @@ func TestFileBadAcceptFileClose(t *testing.T) {
 		t.Error("Accept should return error")
 	}
 
+	err = aw.Close()
+	if err != nil {
+		assertEqual(t, "test error", err.Error())
+	} else {
+		t.Error("Accept should return error")
+	}
+
 	// file is gone
 	by, err = ioutil.ReadFile(aw.filename)
 	if !os.IsNotExist(err) {
@@ -160,6 +167,13 @@ func TestFileBadAcceptTempFileClose(t *testing.T) {
 	badTempFile.CloseErr = errors.New("test error")
 
 	err = aw.Accept()
+	if err != nil {
+		assertEqual(t, "test error", err.Error())
+	} else {
+		t.Error("Accept should return error")
+	}
+
+	err = aw.Close()
 	if err != nil {
 		assertEqual(t, "test error", err.Error())
 	} else {
@@ -217,6 +231,8 @@ func TestFileBadAcceptTempFileSync(t *testing.T) {
 	} else {
 		t.Error("Accept should return error")
 	}
+
+	assertEqual(t, nil, aw.Close())
 
 	// file is gone
 	by, err = ioutil.ReadFile(aw.filename)

--- a/file_test.go
+++ b/file_test.go
@@ -204,7 +204,7 @@ func TestFileLocks(t *testing.T) {
 	for _, name := range files {
 		f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0665)
 		assertEqualf(t, nil, err, "unable to open %s: %s", name, err)
-		cleanupFile(f)
+		cleanupFile(f, name)
 	}
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -129,6 +129,58 @@ func TestFileBadAcceptFileClose(t *testing.T) {
 	assertEqual(t, 0, len(by))
 }
 
+func TestFileBadAcceptTempFileClose(t *testing.T) {
+	test := SetupFile(t)
+	defer test.Teardown()
+
+	// init file
+	filename := filepath.Join(test.Path, supOid)
+	aw, err := NewFile(filename)
+	assertEqual(t, nil, err)
+	assertEqual(t, filename, aw.filename)
+
+	badTempFile := &badFile{File: aw.tempFile.(*os.File)}
+	aw.tempFile = badTempFile
+
+	// write to file
+	n, err := aw.Write([]byte("SUP"))
+	assertEqual(t, nil, err)
+	assertEqual(t, 3, n)
+
+	// check write is saved to temp file
+	by, err := ioutil.ReadFile(aw.tempFilename)
+	assertEqual(t, nil, err)
+	assertEqual(t, "SUP", string(by))
+
+	// check nothing saved to actual file yet
+	by, err = ioutil.ReadFile(filename)
+	assertEqual(t, nil, err)
+	assertEqual(t, 0, len(by))
+
+	badTempFile.CloseErr = errors.New("test error")
+
+	err = aw.Accept()
+	if err != nil {
+		assertEqual(t, "test error", err.Error())
+	} else {
+		t.Error("Accept should return error")
+	}
+
+	// file is gone
+	by, err = ioutil.ReadFile(aw.filename)
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected file not exist error, got: %+v", err)
+	}
+	assertEqual(t, 0, len(by))
+
+	// tempfile is gone
+	by, err = ioutil.ReadFile(aw.tempFilename)
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected file not exist error, got: %+v", err)
+	}
+	assertEqual(t, 0, len(by))
+}
+
 func TestFileMismatch(t *testing.T) {
 	test := SetupFile(t)
 	defer test.Teardown()

--- a/file_test.go
+++ b/file_test.go
@@ -19,6 +19,7 @@ func TestFileAccept(t *testing.T) {
 	filename := filepath.Join(test.Path, supOid)
 	aw, err := NewFile(filename)
 	assertEqual(t, nil, err)
+	assertEqual(t, filename, aw.filename)
 
 	n, err := aw.Write([]byte("SUP"))
 	assertEqual(t, nil, err)
@@ -28,11 +29,21 @@ func TestFileAccept(t *testing.T) {
 	assertEqual(t, nil, err)
 	assertEqual(t, 0, len(by))
 
+	by, err = ioutil.ReadFile(aw.tempFilename)
+	assertEqual(t, nil, err)
+	assertEqual(t, "SUP", string(by))
+
 	assertEqual(t, nil, aw.Accept())
 
 	by, err = ioutil.ReadFile(filename)
 	assertEqual(t, nil, err)
 	assertEqual(t, "SUP", string(by))
+
+	by, err = ioutil.ReadFile(aw.tempFilename)
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected file not exist error, got: %+v", err)
+	}
+	assertEqual(t, 0, len(by))
 
 	assertEqual(t, nil, aw.Close())
 }


### PR DESCRIPTION
This explicitly calls `Sync()` before renaming the tempfile to the destination file, ensuring the file has been flushed to disk. 